### PR TITLE
Do not modify default logger

### DIFF
--- a/norpm/logging.py
+++ b/norpm/logging.py
@@ -4,7 +4,7 @@ Logging configuration for norpm project.
 
 import logging
 
-def get_logger(name=None):
+def get_logger(name='norpm'):
     """Allocate configured logger."""
     log = logging.getLogger(name)
     log.setLevel(logging.DEBUG)


### PR DESCRIPTION
We, e.g., don't want to switch default log level to DEBUG, that would, e.g., cause unexpected logentries in rpmautospec testsuite: https://github.com/fedora-infra/rpmautospec/pull/319