### PR TITLE
Support RPM 6.1+ macro modifiers (<l> and <o>)

### DIFF
--- a/norpm/macro.py
+++ b/norpm/macro.py
@@ -9,15 +9,14 @@ from norpm.exceptions import NorpmInvalidMacroName
 class MacroDefinition:
     """A single macro definition."""
 
-    def __init__(self, value, params):
+    def __init__(self, value, params, modifiers=None):
         self.value = value
         self.params = params
+        self.modifiers = modifiers or set()
 
     def to_dict(self):
         """Get a serializable object."""
-        if self.params is not None:
-            return (self.value, self.params)
-        return (self.value,)
+        return (self.value, self.params, self.modifiers)
 
 
 class Macro:
@@ -26,9 +25,9 @@ class Macro:
     def __init__(self):
         self.stack = []
 
-    def define(self, value, parameters=None):
+    def define(self, value, parameters=None, modifiers=None):
         """Define this macro."""
-        self.stack.append(MacroDefinition(value, parameters))
+        self.stack.append(MacroDefinition(value, parameters, modifiers))
 
     def to_dict(self):
         """Return the last definition of macro as serializable object."""
@@ -52,6 +51,11 @@ class Macro:
     def params(self):
         """True if the latest definition is parametric."""
         return self.stack[-1].params
+
+    @property
+    def modifiers(self):
+        """Modifiers of the latest definition."""
+        return self.stack[-1].modifiers
 
 
 class MacroRegistry:
@@ -82,17 +86,18 @@ class MacroRegistry:
     def define(self, name, value, special=False):
         """(re)define macro"""
         params = None
+        modifiers = None
 
         if not special and not is_macro_name(name):
             raise NorpmInvalidMacroName(f"{name} is not a valid macro name")
 
         if isinstance(value, tuple):
-            value, params = value
+            value, params, modifiers = value
         try:
             macro = self.db[name]
         except KeyError:
             macro = self.db[name] = Macro()
-        macro.define(value, params)
+        macro.define(value, params, modifiers)
 
     def __contains__(self, name):
         return name in self.db

--- a/norpm/macrofile.py
+++ b/norpm/macrofile.py
@@ -19,6 +19,7 @@ class _CTX():
         self.macroname = ""
         self.params = ""
         self.value = ""
+        self.modifiers = ""
 
 
 def macrofile_parse(file_contents, macros, inspec=False):
@@ -26,8 +27,8 @@ def macrofile_parse(file_contents, macros, inspec=False):
     definitions), and store the definitions to macros registry.  See
     macrofile_split_generator() what inspec=True means.
     """
-    for name, value, params in macrofile_split_generator(file_contents, inspec):
-        macros[name] = (value, params)
+    for name, value, params, modifiers in macrofile_split_generator(file_contents, inspec):
+        macros[name] = (value, params, modifiers)
 
 
 def macrofile_split_generator(file_contents, inspec=False):
@@ -50,6 +51,7 @@ def macrofile_split_generator(file_contents, inspec=False):
         ctx.macroname = ""
         ctx.value = ""
         ctx.params = None
+        ctx.modifiers = ""
 
     for c in tokenize(file_contents):
         if ctx.state == "START":
@@ -84,6 +86,10 @@ def macrofile_split_generator(file_contents, inspec=False):
                 ctx.params = ""
                 continue
 
+            if c == '<':
+                ctx.state = 'MODIFIERS'
+                continue
+
             ctx.macroname += c
             continue
 
@@ -94,7 +100,18 @@ def macrofile_split_generator(file_contents, inspec=False):
             ctx.params = ctx.params + c
             continue
 
+        if ctx.state == 'MODIFIERS':
+            if c == '>':
+                ctx.state = "VALUE_START"
+                continue
+            ctx.modifiers += c
+            continue
+
         if ctx.state == "VALUE_START":
+            if c == '<':
+                ctx.state = 'MODIFIERS'
+                continue
+
             if inspec and c == "\n":
                 ctx.value += "\n"
                 ctx.state = "VALUE"
@@ -104,6 +121,13 @@ def macrofile_split_generator(file_contents, inspec=False):
                 if not inspec:
                     ctx.value += "\n"
                     ctx.state = "VALUE"
+                continue
+            # In macro files a bare newline terminates the definition (even
+            # with an empty body, e.g. '%foo()\n').  Without this, '\n' would
+            # fall through to isspace() and be silently swallowed.
+            if c == '\n' and not inspec:
+                yield ctx.macroname, ctx.value.rstrip(), ctx.params, set(ctx.modifiers)
+                _reset()
                 continue
             if c.isspace():
                 continue
@@ -136,7 +160,7 @@ def macrofile_split_generator(file_contents, inspec=False):
                     ctx.value += c
                 continue
             if c == '\n' and not inspec:
-                yield ctx.macroname, ctx.value.rstrip(), ctx.params
+                yield ctx.macroname, ctx.value.rstrip(), ctx.params, set(ctx.modifiers)
                 _reset()
                 continue
 
@@ -149,10 +173,10 @@ def macrofile_split_generator(file_contents, inspec=False):
             continue
 
     if ctx.state == "VALUE":
-        yield ctx.macroname, ctx.value.rstrip(), ctx.params
+        yield ctx.macroname, ctx.value.rstrip(), ctx.params, set(ctx.modifiers)
 
     if ctx.state == "VALUE_START" and inspec:
-        yield ctx.macroname, ctx.value.rstrip(), ctx.params
+        yield ctx.macroname, ctx.value.rstrip(), ctx.params, set(ctx.modifiers)
 
 
 def _get_macro_files(arch, prefix):

--- a/norpm/overrides.py
+++ b/norpm/overrides.py
@@ -50,7 +50,8 @@ def override_macro_registry(original_registry, overrides_filename, tag):
                     registry.define(macroname, definition["value"])
                 else:
                     registry.define(macroname, (definition["value"],
-                                                definition["params"]))
+                                                definition["params"],
+                                                set()))
         if not found:
             _warn_once(f"Tag \"{tag}\" is not defined in "
                        f"\"{overrides_filename}\" database, macros "

--- a/norpm/specfile.py
+++ b/norpm/specfile.py
@@ -19,13 +19,18 @@ from dataclasses import dataclass
 import re
 
 from norpm.tokenize import tokenize, Special, BRACKET_TYPES, OPENING_BRACKETS
-from norpm.macro import is_macro_character, parse_macro_call, drop_curly_brackets
+from norpm.macro import (is_macro_character, parse_macro_call,
+                         drop_curly_brackets, MacroDefinition)
 from norpm.macrofile import macrofile_parse, macrofile_split_generator
 from norpm.getopt import getopt
 from norpm.logging import get_logger
 from norpm.expression import eval_rpm_expr
 from norpm.exceptions import NorpmSyntaxError, NorpmRecursionError
 from norpm.builtins import BUILTINS, QuotedString
+
+
+class LiteralString(str):
+    """Marker for macro results that should not be re-expanded."""
 
 log = get_logger()
 
@@ -497,6 +502,19 @@ class _HideAndSeekMacro:
         return self.expand(string)
 
 
+def _apply_oneshot(context, retval, name, definitions, modifiers, depth):
+    if 'o' not in modifiers:
+        return retval
+    expanded = _specfile_expand_string(context, str(retval), definitions, depth+1)
+    # Replace the oneshot definition in-place with the cached literal so that
+    # %undefine pops this single entry and exposes the previous stack level
+    # (e.g. a plain %define).  Pushing a new entry would leave the oneshot
+    # definition underneath, causing it to re-trigger after %undefine.
+    macro = definitions[name]
+    macro.stack[-1] = MacroDefinition(expanded, None)
+    return expanded
+
+
 def _expand_snippet(context, snippet, definitions, depth=0):
     full_snippet = snippet
     snippet = full_snippet.text
@@ -630,10 +648,19 @@ def _expand_snippet(context, snippet, definitions, depth=0):
         return retval
     if retval == "":
         return retval
-    if not params:
-        return retval
-    if definitions[name].params is None:
-        return retval
+
+    macro = definitions[name]
+    modifiers = macro.modifiers
+
+    if 'l' in modifiers:
+        return LiteralString(retval)
+
+    # No params given by caller, or macro has no parameter spec — return the
+    # body directly.  We still must go through _apply_oneshot so that a
+    # oneshot ('<o>') macro gets expanded-and-cached on first use even when
+    # it is invoked without arguments (e.g. %define foo<o> %bar).
+    if not params or macro.params is None:
+        return _apply_oneshot(context, retval, name, definitions, modifiers, depth)
 
     # RPM also first expands the parameters before calling getopt()
     params = _expand_params(context, params, definitions, depth+1)
@@ -642,7 +669,7 @@ def _expand_snippet(context, snippet, definitions, depth=0):
     if params and params[0].startswith('%'):
         return retval
 
-    optlist, args = getopt(params, definitions[name].params)
+    optlist, args = getopt(params, macro.params)
 
     # Temporarily define '%1', '%*', '%-f', etc.
     for opt, arg in optlist:
@@ -932,14 +959,25 @@ def _specfile_expand_string_generator(context, string, macros, depth=0,
 
             definition = drop_curly_brackets(buffer)
             _, definition = definition.split(maxsplit=1)
-            expanded_def = specfile_expand_string(definition, macros, depth+1)
-            for name, body, params in macrofile_split_generator('%' + expanded_def, inspec=True):
-                macros[name] = (body, params)
+            name, body, params, modifiers = next(  # pylint: disable=stop-iteration-return
+                macrofile_split_generator('%' + definition, inspec=True))
+
+            if 'l' not in modifiers:
+                expanded_def = specfile_expand_string(definition, macros, depth+1)
+                name, body, params, _ = next(  # pylint: disable=stop-iteration-return
+                    macrofile_split_generator('%' + expanded_def, inspec=True))
+
+            macros[name] = (body, params, modifiers)
             continue
 
         quoted = False
         expanded = _expand_snippet(context, snippet, macros, depth)
         if expanded is None:
+            continue
+
+        if isinstance(expanded, LiteralString):
+            if context.expanding:
+                yield str(expanded)
             continue
 
         if isinstance(expanded, QuotedString):

--- a/norpm/tokenize.py
+++ b/norpm/tokenize.py
@@ -3,7 +3,14 @@ RPM source file tokenizer
 """
 
 class Special:
-    """ Special token """
+    """
+    Special character token.
+    If '\n' is wrapped by Special, it is an escaped newline ('\\' is at the end
+    of the line).
+    If other characters are wrapped by Special, these are RPM controlling
+    characters like '{', '}' (without Special wrapper, these are meant to be
+    text-only characters (escaped curly bracket))
+    """
     def __init__(self, char):
         self.char = char
     def __str__(self):

--- a/pylintrc
+++ b/pylintrc
@@ -73,6 +73,9 @@ bad-names=foo,bar,baz,toto,tutu,tata
 
 [DESIGN]
 
+# Maximum number of positional arguments for function / method
+max-positional-arguments=6
+
 # Maximum number of arguments for function / method
 max-args=1000
 
@@ -106,7 +109,7 @@ max-public-methods=1000
 max-line-length=120
 
 # Maximum number of lines in a module
-max-module-lines=1000
+max-module-lines=1500
 
 # String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
 # tab).

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -139,14 +139,14 @@ def test_empty_expansion_in_epxr():
 %{expand:%%global %{1}_version_diff %{gsub %2 %d+: %{quote:}}}
 %{expand:%%global %{1}_version %%sub %2 %%[1 + %%{len:%2} - %%{len:%%%{1}_version_diff}]  %%{len:%2}}
 %{expand:%%global %{1}_epoch %%sub %2 1 %%[%%{len:%2} - %%{len:%%%{1}_version_diff} - 1]}
-''', '')
+''', '', set())
 
     db["nodejs_define_version2"] = ('''\
 %{expand:%%global %{1}_evr %2}
 %{expand:%%global %{1}_version_diff %{gsub %2 %d+: %{quote:}}}
 %{expand:%%global %{1}_version %%sub %2 %%{expr:1 + %%{len:%2} - %%{len:%%%{1}_version_diff}}  %%{len:%2}}
 %{expand:%%global %{1}_epoch %%sub %2 1 %%{expr:%%{len:%2} - %%{len:%%%{1}_version_diff} - 1}}
-''', '')
+''', '', set())
 
     assert specfile_expand("""\
 %nodejs_define_version foo 666:1.1.1-2

--- a/tests/test_rpmmacros.py
+++ b/tests/test_rpmmacros.py
@@ -11,27 +11,27 @@ from norpm.macrofile import macrofile_parse, macrofile_split_generator
 def test_basicdef():
     macros = MacroRegistry()
     macrofile_parse("%foo bar", macros)
-    assert macros.to_dict() == {"foo": ("bar",)}
+    assert macros.to_dict() == {"foo": ("bar", None, set())}
     macrofile_parse(
         "%baz bar %{\n"
         " foo}\n",
         macros
     )
     assert macros.to_dict() == {
-        "foo": ("bar",),
-        "baz": ("bar %{\n foo}",),
+        "foo": ("bar", None, set()),
+        "baz": ("bar %{\n foo}", None, set()),
     }
     macrofile_parse(
         "%blah(p:) %x %y -p*",
         macros
     )
     assert macros.to_dict() == {
-        "foo": ("bar",),
-        "baz": ("bar %{\n foo}",),
-        "blah": ( "%x %y -p*", "p:"),
+        "foo": ("bar", None, set()),
+        "baz": ("bar %{\n foo}", None, set()),
+        "blah": ("%x %y -p*", "p:", set()),
     }
 
-    assert macros["foo"].to_dict() == ("bar",)
+    assert macros["foo"].to_dict() == ("bar", None, set())
     assert "foo" in macros
 
 
@@ -48,7 +48,7 @@ def test_newline():
         " %bar blah\\\n"
         " and \\blah",
         macros)
-    assert macros.to_dict() == {"foo": ("\n %bar blah\n and blah",)}
+    assert macros.to_dict() == {"foo": ("\n %bar blah\n and blah", None, set())}
 
 def test_trailing_space():
     macros = MacroRegistry()
@@ -57,31 +57,31 @@ def test_trailing_space():
         " %bar blah \\\n"
         " and spaces:    	",
         macros)
-    assert macros.to_dict() == {"foo": ("\n %bar blah \n and spaces:",)}
+    assert macros.to_dict() == {"foo": ("\n %bar blah \n and spaces:", None, set())}
 
 
 def test_backslashed():
     macros = MacroRegistry()
     macrofile_parse("%foo %{\\}\n}\n", macros)
-    assert macros.to_dict() == {"foo": ("%{}\n}",)}
+    assert macros.to_dict() == {"foo": ("%{}\n}", None, set())}
 
 def test_bash_parser():
     macros = MacroRegistry()
     macrofile_parse("%foo %(echo ahoj)\n", macros)
-    assert macros.to_dict() == {"foo": ("%(echo ahoj)",)}
+    assert macros.to_dict() == {"foo": ("%(echo ahoj)", None, set())}
     macrofile_parse("%bar %(\necho barcontent)\n", macros)
     assert macros["bar"].value == "%(\necho barcontent)"
 
 def test_ignore_till_eol():
     macros = MacroRegistry()
     macrofile_parse("foo %bar baz\nblah\n%recover foo", macros)
-    assert macros.to_dict() == {"recover": ("foo",)}
+    assert macros.to_dict() == {"recover": ("foo", None, set())}
 
 
 def test_whitespice_before_name():
     macros = MacroRegistry()
     macrofile_parse(" % bar baz", macros)
-    assert macros.to_dict() == {"bar": ("baz",)}
+    assert macros.to_dict() == {"bar": ("baz", None, set())}
 
 
 def test_whitespace_start():
@@ -96,16 +96,16 @@ def test_whitespace_start():
 
 def test_inspec_parser():
     parts = list(macrofile_split_generator("%foo \nblah\n", inspec=True))
-    assert parts == [("foo", "\nblah", None)]
+    assert parts == [("foo", "\nblah", None, set())]
 
     parts = list(macrofile_split_generator("%foo() \nblah\n", inspec=True))
-    assert parts == [("foo", "\nblah", "")]
+    assert parts == [("foo", "\nblah", "", set())]
 
     parts = list(macrofile_split_generator("%foo() \nblah	  \n", inspec=True))
-    assert parts == [("foo", "\nblah", "")]
+    assert parts == [("foo", "\nblah", "", set())]
 
     parts = list(macrofile_split_generator("%foo(p: ) \nblah\n", inspec=True))
-    assert parts == [("foo", "\nblah", "p: ")]
+    assert parts == [("foo", "\nblah", "p: ", set())]
 
 def test_forgemeta_parser():
     macro_def = """\

--- a/tests/test_spec_expansion.py
+++ b/tests/test_spec_expansion.py
@@ -12,6 +12,7 @@ from norpm.specfile import (
     specfile_expand_generator,
 )
 from norpm.macro import MacroRegistry
+from norpm.macrofile import macrofile_split_generator
 from norpm.exceptions import NorpmRecursionError
 
 
@@ -491,3 +492,118 @@ def test_definition_with_curly_brackets():
  a b c
 034
 """
+
+
+def test_literal_modifier():
+    db = MacroRegistry()
+    db["bar"] = "expanded_bar"
+    assert specfile_expand_string("%define foo<l> %bar\n%foo", db) == "%bar"
+
+
+def test_literal_modifier_double_percent():
+    db = MacroRegistry()
+    assert specfile_expand_string("%define foo<l> some%%thing\n%foo", db) == "some%%thing"
+
+
+def test_literal_modifier_global():
+    db = MacroRegistry()
+    db["bar"] = "expanded_bar"
+    spec = "%global foo<l> %bar\n%foo"
+    assert specfile_expand_string(spec, db) == "%bar"
+    assert db["foo"].value == "%bar"
+
+
+def test_literal_modifier_global_no_expand():
+    db = MacroRegistry()
+    db["bar"] = "expanded_bar"
+    spec = "%global foo<l> %bar\n"
+    specfile_expand_string(spec, db)
+    assert db["foo"].value == "%bar"
+
+
+def test_oneshot_modifier():
+    db = MacroRegistry()
+    db["bar"] = "result"
+    spec = "%define foo<o> %bar\n%foo %foo"
+    assert specfile_expand_string(spec, db) == "result result"
+
+
+def test_oneshot_caches_result():
+    db = MacroRegistry()
+    db["counter"] = "first"
+    specfile_expand_string("%define cached<o> %counter\n%cached", db)
+    db["counter"] = "second"
+    assert specfile_expand_string("%cached", db) == "first"
+
+
+def test_global_oneshot_expands_twice():
+    """%global<o> expands the body twice: once at definition, once on first use."""
+    db = MacroRegistry()
+    result = specfile_expand_string(
+        "%global value final\n"
+        "%global indirect %%value\n"
+        "%global cached<o> %indirect\n"
+        "%cached", db)
+    assert result == "final"
+
+
+def test_global_oneshot_deferred_use():
+    """One-shot fires on first use — picks up the value of %bar at that time."""
+    db = MacroRegistry()
+    specfile_expand_string("%global foo<o> %%bar\n", db)
+    specfile_expand_string("%global bar final\n", db)
+    specfile_expand_string("%global bar final2\n", db)
+    assert specfile_expand_string("%foo", db) == "final2"
+
+
+def test_global_oneshot_caches_on_first_use():
+    """One-shot caches the result on first use; later redefinitions don't affect it."""
+    db = MacroRegistry()
+    specfile_expand_string("%global foo<o> %%bar\n", db)
+    specfile_expand_string("%global bar final\n", db)
+    assert specfile_expand_string("%foo", db) == "final"
+    specfile_expand_string("%global bar final2\n", db)
+    assert specfile_expand_string("%foo", db) == "final"
+
+
+def test_oneshot_rearm_by_undefine():
+    db = MacroRegistry()
+    result = specfile_expand_string(
+        "%global counter first\n"
+        "%define cached %counter\n"
+        "%cached\n"
+        "%global counter second\n"
+        "%cached\n"
+        "%define cached<o> %counter\n"
+        "%cached\n"
+        "%global counter third\n"
+        "%cached\n"
+        "%undefine cached\n"
+        "%cached\n"
+        "%global counter fourth\n"
+        "%cached", db)
+    assert result == "first\nsecond\nsecond\nsecond\n\nthird\nfourth"
+
+
+def test_literal_macro_used_in_definition():
+    db = MacroRegistry()
+    spec = "%define bar<l> %something\n%define foo %bar\n%foo"
+    assert specfile_expand_string(spec, db) == "%something"
+
+
+def test_modifier_with_params():
+    db = MacroRegistry()
+    parts = list(specfile_expand_string_generator(
+        "%define foo()<l> body\n%foo", db))
+    assert "".join(parts) == "body"
+
+
+def test_modifier_parsing_in_macrofile():
+    parts = list(macrofile_split_generator("%foo<l> body\n"))
+    assert parts == [("foo", "body", None, {'l'})]
+
+    parts = list(macrofile_split_generator("%bar()<o> body\n"))
+    assert parts == [("bar", "body", "", {'o'})]
+
+    parts = list(macrofile_split_generator("%baz(p:)<lo> body\n"))
+    assert parts == [("baz", "body", "p:", {'l', 'o'})]

--- a/tests/test_spec_parser.py
+++ b/tests/test_spec_parser.py
@@ -27,7 +27,7 @@ def test_basic_spec():
 
 def test_parametric_line():
     macros = MacroRegistry()
-    macros["foo"] = ("a %1 b", "")
+    macros["foo"] = ("a %1 b", "", set())
     macros["bar"] = "a %1 b"
     assert macros["foo"].parametric
     assert not macros["bar"].parametric


### PR DESCRIPTION
RPM 6.1.0 introduced macro definition modifiers specified via angle brackets after the macro name or params, e.g. '%define foo<l> body' or '%global bar()<o> body'.

The <l> (literal) modifier prevents re-expansion of the macro body — the value is returned as-is, preserving any % characters.  With %global, the definition-time expansion is also skipped so the raw body is stored.

The <o> (oneshot) modifier expands the body on first use and replaces the definition in-place with the cached result.  Subsequent references return the cached value without re-expanding.  The oneshot can be re-armed by %undefine (which pops the cached entry and exposes the previous stack level).

The VALUE_START state in the macrofile parser now handles '<' to enter a MODIFIERS state, which also removed the need for a separate POST_PARAMS state (its logic was duplicated from VALUE_START). A bare '\n' check was added to VALUE_START because without it, a newline after ')' in macro files would fall through to the isspace() handler and be silently swallowed instead of terminating the definition.

MacroDefinition.to_dict() now always returns a 3-tuple (value, params, modifiers) for consistency, and all callers have been updated accordingly.

Assisted-By: Claude Opus <noreply@anthropic.com>