### PR TITLE
Make MacroRegistry.define() more flexible

### DIFF
--- a/norpm/macro.py
+++ b/norpm/macro.py
@@ -92,7 +92,8 @@ class MacroRegistry:
             raise NorpmInvalidMacroName(f"{name} is not a valid macro name")
 
         if isinstance(value, tuple):
-            value, params, modifiers = value
+            # ensure there’s enough to unpack
+            value, params, modifiers, *_ = value + (None, None)
         try:
             macro = self.db[name]
         except KeyError:


### PR DESCRIPTION
With this, `define()` doesn’t expect a `value` tuple to contain all elements, `params` and `modifiers` are assumed to be `None` if missing.